### PR TITLE
Fix file watch locking

### DIFF
--- a/abstract
+++ b/abstract
@@ -122,8 +122,10 @@ function waitForPhantom(process) {
 function watcher() {
 	let watchFunction = function watchFunction() {
 		fs.readFile(opts.source, "utf8")
-		.then((md) => {
-			(isProcessing) ? setTimeout(arguments.callee, 1000) : processMd(md);
+		.then(function loop(md) {
+			(isProcessing)
+				? setTimeout(loop.bind(null, md), 1000) 
+				: processMd(md);
 		})
 		.catch(handleError);
 	};


### PR DESCRIPTION
Had to lose a pretty lambda to avoid using `arguments.callee`, but it does fix the bug!

For future reference, the way I tested it was `touch complex.md && sleep 0.2 && touch complex.md`.